### PR TITLE
Administrative area bug fix

### DIFF
--- a/geolocation/geocode/models.py
+++ b/geolocation/geocode/models.py
@@ -2,7 +2,6 @@
 
 
 class LocationModel(object):
-    _administrative_area = list()
 
     def __init__(self, **kwargs):
         self.city = kwargs.get('city')
@@ -14,6 +13,7 @@ class LocationModel(object):
         self.lat = kwargs.get('lat')
         self.lng = kwargs.get('lng')
         self.formatted_address = kwargs.get('formatted_address')
+    	self._administrative_area = list()
 
     def __repr__(self):
         return '<LocationModel: %s>' % self.city

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -125,16 +125,12 @@ class GeolocationTest(unittest.TestCase):
 
     def test_administrative_area_resets(self):
         address = "São Paulo"
+        sao_paulo = self.google_maps.search(address).first()
 
-        my_location = self.google_maps.search(address).first()
+        address = "Houston, TX"
+        houston = self.google_maps.search(address).first()
 
-        self.assertEqual(len(my_location.administrative_area), 2)
-
-        address = "Rio de Janeiro"
-
-        my_location = self.google_maps.search(address).first()
-
-        self.assertEqual(len(my_location.administrative_area), 2)
+        self.assertNotEqual(sao_paulo, houston)
 
 
 class DistanceMatrixTest(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -123,6 +123,19 @@ class GeolocationTest(unittest.TestCase):
 
         self.assertEqual('Mountain View', my_location.city.decode('utf-8'))
 
+    def test_administrative_area_resets(self):
+        address = "São Paulo"
+
+        my_location = self.google_maps.search(address).first()
+
+        self.assertEqual(len(my_location.administrative_area), 2)
+
+        address = "Rio de Janeiro"
+
+        my_location = self.google_maps.search(address).first()
+
+        self.assertEqual(len(my_location.administrative_area), 2)
+
 
 class DistanceMatrixTest(unittest.TestCase):
     def setUp(self):
@@ -213,3 +226,7 @@ class DistanceMatrixTest(unittest.TestCase):
         self.assertEqual(item.distance.meters, 1851000)
         self.assertEqual(item.distance.miles, 1150.1559)
         self.assertEqual(str(item.duration), '0d 17h 35m 44s')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Changed administrative_area from a class attribute to an instance attribute. This fixes an issue where multiple search results would share the same list of administrative areas.

To see this bug, open up a python shell and search for two different places.

>>> from geolocation.google_maps import GoogleMaps 
>>> maps = GoogleMaps('AIzaSyDNvdrZ_HEtfsuPYHV9UvZGc41BSFBolOM')
>>> houston = maps.search('Houston, TX').first()
>>> rio = maps.search('Rio de Janeiro').first()
>>> houston.administrative_area is rio.administrative_area
True