### PR TITLE
Fixing issue where we werent checking for sublocality if locality was not found

### DIFF
--- a/geolocation/geocode/parsers.py
+++ b/geolocation/geocode/parsers.py
@@ -48,7 +48,10 @@ class GeocodeParser(Parser):
 
     def get_city(self):
         """Method should returns city long name of current location."""
-        return self.search_address_components('locality')
+        city = self.search_address_components('locality')
+        if not city:
+            city = self.search_address_components('sublocality')
+        return city
 
     def get_country(self):
         """Method should returns country long name from current location."""


### PR DESCRIPTION
I was able to find many addresses that didn't have locality, only sublocality.  Here is an example:

`2136 Bartow Avenue,Bronx,NY,10475`